### PR TITLE
Pass options.browserify in to browserify constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,9 +34,10 @@ function bundleify (options, callback) {
   const entry = path.resolve(options.basedir, options.entry)
   const compress = Compressor(options)
 
-  browserify({
-    debug: true
-  })
+  browserify(extend(
+    {debug: true},
+    options.browserify
+  ))
   .add(entry)
   .require(entry, {expose: 'app'})
   .plugin(customize, options)


### PR DESCRIPTION
My use-case: I'm creating a standalone bundle via browserify's `--standalone` option. I'm also using browserify's `--exclude` option.

This also possibly allows people to shoot themselves in the foot (eg if they passed in `options.browserify.files`), but I think it's worth it for the power it gives.